### PR TITLE
Makefile changes: git describe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ endif
 
 include $(DEVKITARM)/ds_rules
 
-export GAME_TITLE	:=	GameYob `git describe`
+export GAME_TITLE	:=	GameYob `git describe --always --abbrev=4`
 export GAME_SUBTITLE1	:=	A Gameboy emulator for DS
 export GAME_SUBTITLE2	:=	Author: Drenn
 export GAME_ICON	:=	$(CURDIR)/icon.bmp


### PR DESCRIPTION
I have never managed to get the NDS file to have a git commit hash with your Makefile. Near the end of each build, I would get this message:

> fatal: No names found, cannot describe anything.

I modified the Makefile and it now has a 4-digit commit name for me. That will be shorter for users to copy-paste while still accomodating a repository with thousands of commits.

If you want to continue using the 7-digit hashes, remove --abbrev=4 after merging.
