### PR TITLE
Updated quit to launcher flavor text; read info

### DIFF
--- a/arm9/source/console.cpp
+++ b/arm9/source/console.cpp
@@ -208,7 +208,7 @@ ConsoleSubMenu menuList[] = {
         "Options",
         7,
         {0,         10,                                         0,              0,              0,          0,     			0},
-        {"Suspend", "State Slot",                               "Save State",   "Load State",   "Reset",    "Save & Exit", 	"Quit to launcher"},
+        {"Suspend", "State Slot",                               "Save State",   "Load State",   "Reset",    "Save & Exit", 	"Quit to Launcher/Reboot"},
         {{},        {"0","1","2","3","4","5","6","7","8","9"},  {},             {},             {},         {}, 			{}},
         {suspendFunc,stateSelectFunc,                         stateSaveFunc,  stateLoadFunc,  resetFunc,    exitFunc, 		returnToLauncherFunc},
         {0,             0,                                      0,              0,              0,          0, 				0}


### PR DESCRIPTION
Just figured out that calling exit(0) or returning from main on a card that _does not support_ the Exit-to-Menu protocol, will actually reboot the console, so there's no need to have a separate function for it.
