### PR TITLE
Makefile tweaks to suppress va_list warnings

### DIFF
--- a/arm7/Makefile
+++ b/arm7/Makefile
@@ -29,7 +29,7 @@ INCLUDES	:=	include ../common build
 #---------------------------------------------------------------------------------
 ARCH	:=	-march=armv4t -mthumb -mthumb-interwork
 
-CFLAGS	:=	-g -Wall -O2\
+CFLAGS	:=	-g -Wall -Wno-psabi -O2\
  		-mcpu=arm7tdmi -mtune=arm7tdmi -fomit-frame-pointer\
 		-ffast-math \
 		$(ARCH)

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -25,7 +25,7 @@ DATA		:=
 #---------------------------------------------------------------------------------
 ARCH	:=	# -mthumb -mthumb-interwork	#This may cause some problem when there are some cross-calls between C&Assembly. It also ends up being slower than non-Thumb code.
 
-CFLAGS	:=	-Wall -DNO_VIZ\
+CFLAGS	:=	-Wall -Wno-psabi -DNO_VIZ\
  			-march=armv5te -mtune=arm946e-s -fomit-frame-pointer\
 			-ffast-math -O3 -g \
 			$(ARCH)


### PR DESCRIPTION
There's a bug in devkitPro's version of GCC that warns of PSABI issues
in system headers even though they aren't needed for them. This is fixed
in a newer version of GCC that devkitPro has not yet adopted.

http://gcc.gnu.org/bugzilla/show_bug.cgi?id=42748
