### PR TITLE
Hack to fix tearing for 3DS.

### DIFF
--- a/platform/3ds/inputhelper.cpp
+++ b/platform/3ds/inputhelper.cpp
@@ -129,12 +129,13 @@ void system_checkPolls() {
         gspWaitForVBlank();
     }
 
-    gfxFlushBuffers();
+    // gfxFlushBuffers();
     gfxMySwapBuffers();
     consoleCheckFramebuffers();
 }
 
 void system_waitForVBlank() {
+    gfxFlushBuffers();
     gspWaitForVBlank();
 }
 


### PR DESCRIPTION
The same hack I wrote about in the GBA temp thread. This seems to work favorably with most roms, except some of the more laden ones (like Shantae or BADAPPLE.gbc) which run slower when compared to before.
