### PR TITLE
Added support for binding 3DS and New 3DS buttons on 3DS-based systems

### DIFF
--- a/platform/common/config.cpp
+++ b/platform/common/config.cpp
@@ -319,9 +319,9 @@ void updateKeyConfigChooser() {
         if (option == NUM_BINDABLE_BUTTONS-1)
             option = -1;
 #if defined(_3DS)
-        else if(option > 10 && option < 13) //Skip nonexistant keys
+        else if(option == 11) //Skip nonexistant keys
             option = 14;
-        else if(option > 14 && option < 23)
+        else if(option == 15)
             option = 24;
 #endif
         else
@@ -332,9 +332,9 @@ void updateKeyConfigChooser() {
         if (option == -1)
             option = NUM_BINDABLE_BUTTONS-1;
 #if defined(_3DS)
-        else if(option > 10 && option < 13) //Skip nonexistant keys
+        else if(option == 14) //Skip nonexistant keys
             option = 11;
-        else if(option > 14 && option < 23)
+        else if(option == 24)
             option = 15;
 #endif
         else


### PR DESCRIPTION
Adds support for the binding and using of the Circle Pad on 3DS systems to their own bindable buttons for the emulator. Also adds support for the New 3DS's ZL, ZR, and C-Stick buttons as well. Since detecting a New 3DS vs a normal 3DS is out of the scope of ctrulib (for now, or as it seems), it allows you to bind for these buttons even on a 3DS, 3DS XL, or 2DS system.

Since a few bits within the input u32 are unassigned, these bits had to be worked around a bit to prevent things from being wonky in the editor. The two strings prompting to press X or Y also had to be adjusted.
